### PR TITLE
Docs for Netlify Image CDN implementation

### DIFF
--- a/docs/content/3.providers/netlify.md
+++ b/docs/content/3.providers/netlify.md
@@ -12,7 +12,9 @@ When deploying your Nuxt applications to [Netlify's composable platform](https:/
 
 This provider is automatically enabled in Netlify deployments.
 
-You can also manually enable this provider for sites deployed on other platforms. To do so, add the following to your Nuxt configuration:
+## Local development 
+
+You can also manually enable this provider for local development. To do so, add the following to your Nuxt configuration:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
@@ -22,9 +24,7 @@ export default defineNuxtConfig({
 })
 ```
 
-::callout
-If you manually enable the `netlify` provider and want to test image transformations locally, use [Netlify Dev](https://docs.netlify.com/cli/local-development/). This feature of the Netlify CLI runs a local development server that mimics Netlify Image CDN.
-::
+Then, to test image transformations locally, use [Netlify Dev](https://docs.netlify.com/cli/local-development/). This feature of the Netlify CLI runs a local development server that mimics the Netlify production environment, including Netlify Image CDN.
 
 ## Remote images
 

--- a/docs/content/3.providers/netlify.md
+++ b/docs/content/3.providers/netlify.md
@@ -39,7 +39,7 @@ The `remote_images` property accepts an array of regex. If your images are in sp
 
 ## Modifiers
 
-Beyond the [standard properties](https://image.nuxt.com/usage/nuxt-img), you can use the [Netlify Image CDN `position` parameter](https://docs.netlify.com/image-cdn/overview/#positions) as a modifier for Nuxt Image.
+Beyond the [standard properties](https://image.nuxt.com/usage/nuxt-img), you can use the [Netlify Image CDN `position` parameter](https://docs.netlify.com/image-cdn/overview/#position) as a modifier for Nuxt Image.
 
 ```vue
 <NuxtImg

--- a/docs/content/3.providers/netlify.md
+++ b/docs/content/3.providers/netlify.md
@@ -10,11 +10,9 @@ links:
 
 When deploying your Nuxt applications to [Netlify's composable platform](https://docs.netlify.com/platform/overview/), the image module uses [Netlify Image CDN](https://docs.netlify.com/image-cdn/overview/) to optimize and transform images on demand without impacting build times. Netlify Image CDN also handles content negotiation to use the most efficient image format for the requesting client.
 
-This provider is automatically enabled in Netlify deployments.
+This provider is automatically enabled in Netlify deployments, and also when running locally using [the Netlify CLI](https://docs.netlify.com/cli/local-development/).
 
-## Local development 
-
-You can also manually enable this provider for local development. To do so, add the following to your Nuxt configuration:
+You can also manually enable this provider. To do so, set the provider to `netlify` or add the following to your Nuxt configuration:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
@@ -24,7 +22,9 @@ export default defineNuxtConfig({
 })
 ```
 
-Then, to test image transformations locally, use [Netlify Dev](https://docs.netlify.com/cli/local-development/). This feature of the Netlify CLI runs a local development server that mimics the Netlify production environment, including Netlify Image CDN.
+## Local development 
+
+To test image transformations locally, use [Netlify Dev](https://docs.netlify.com/cli/local-development/). This feature of the Netlify CLI runs a local development server that mimics the Netlify production environment, including Netlify Image CDN.
 
 ## Remote images
 
@@ -57,12 +57,12 @@ Beyond the [standard properties](https://image.nuxt.com/usage/nuxt-img), you can
 ## Deprecated Netlify Large Media option
 
 ::callout{color="amber" icon="i-ph-warning-duotone"}
-Netlify’s Large Media service is [deprecated](https://answers.netlify.com/t/large-media-feature-deprecated-but-not-removed/100804). If this feature is already enabled for your site on Netlify and you have already set `provider: 'netlify'` in your Nuxt configuration, then Large Media continues to work on your site as usual. However, new Large Media configuration is not recommended.
+Netlify’s Large Media service is [deprecated](https://answers.netlify.com/t/large-media-feature-deprecated-but-not-removed/100804). If this feature is already enabled for your site on Netlify and you have already set `provider: 'netlify'` in your Nuxt configuration, then this will be detected at build time and Large Media continues to work on your site as usual. You can also explicitly enable it by setting `provider: 'netlifyLargeMedia'`. However, new Large Media configuration is not recommended.
 ::
 
 ### Migrate to Netlify Image CDN
 
-To migrate from the deprecated Netlify Large Media option to the more robust Netlify Image CDN option, change `provider: 'netlify'` to `provider: 'netlifyImageCdn'`.
+To migrate from the deprecated Netlify Large Media option to the more robust Netlify Image CDN option, change `provider: 'netlify'` to `provider: 'netlifyImageCdn'`. This will enable the Netlify Image CDN service, even if large media is enabled on your site.
 
 
 ### Use deprecated Netlify Large Media option

--- a/docs/content/3.providers/netlify.md
+++ b/docs/content/3.providers/netlify.md
@@ -24,7 +24,7 @@ export default defineNuxtConfig({
 
 ::callout
 If you manually enable the `netlify` provider and want to test image transformations locally, use [Netlify Dev](https://docs.netlify.com/cli/local-development/). This feature of the Netlify CLI runs a local development server that mimics Netlify Image CDN.
-:::
+::
 
 ## Remote images
 

--- a/docs/content/3.providers/netlify.md
+++ b/docs/content/3.providers/netlify.md
@@ -8,9 +8,11 @@ links:
     size: xs
 ---
 
-When deploying your Nuxt applications to [Netlify's composable platform](https://docs.netlify.com/platform/overview/), the image module can use [Netlify Image CDN](https://docs.netlify.com/image-cdn/overview/) to optimize and transform images on demand without impacting build times. Netlify Image CDN also handles content negotiation to use the most efficient image format for the requesting client.
+When deploying your Nuxt applications to [Netlify's composable platform](https://docs.netlify.com/platform/overview/), the image module uses [Netlify Image CDN](https://docs.netlify.com/image-cdn/overview/) to optimize and transform images on demand without impacting build times. Netlify Image CDN also handles content negotiation to use the most efficient image format for the requesting client.
 
-To use Netlify Image CDN by default, add the following to your Nuxt configuration:
+This provider is automatically enabled in Netlify deployments.
+
+You can also manually enable this provider for sites deployed on other platforms. To do so, add the following to your Nuxt configuration:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
@@ -19,6 +21,10 @@ export default defineNuxtConfig({
   }
 })
 ```
+
+::callout
+If you manually enable the `netlify` provider and want to test image transformations locally, use [Netlify Dev](https://docs.netlify.com/cli/local-development/). This feature of the Netlify CLI runs a local development server that mimics Netlify Image CDN.
+:::
 
 ## Remote images
 
@@ -33,20 +39,18 @@ The `remote_images` property accepts an array of regex. If your images are in sp
 
 ## Modifiers
 
-In addition to the [standard properties](https://image.nuxt.com/usage/nuxt-img), all of the [Netlify Image CDN transformation options](https://docs.netlify.com/image-cdn/overview/#transform-images) are available as modifiers for Nuxt Image.
+Beyond the [standard properties](https://image.nuxt.com/usage/nuxt-img), you can use the [Netlify Image CDN `position` parameter](https://docs.netlify.com/image-cdn/overview/#positions) as a modifier for Nuxt Image.
 
 ```vue
 <NuxtImg
   provider="netlify"
   src="owl.jpg"
-  :modifiers="{ 
-    h="400"
-    w="600"
-    fit="cover"
-    position="left"
-    fm="webp"
-    q="80"
-  }"
+  height="400"
+  width="600"
+  fit="cover"
+  format="webp"
+  quality="80"
+  :modifiers="{ position: 'left' }"
 />
 ```
 

--- a/docs/content/3.providers/netlify.md
+++ b/docs/content/3.providers/netlify.md
@@ -33,7 +33,7 @@ The `remote_images` property accepts an array of regex. If your images are in sp
 
 ## Modifiers
 
-In addition to the [standard modifiers](https://image.nuxt.com/usage/nuxt-img#modifiers), all of the [Netlify Image CDN transformation options](https://docs.netlify.com/image-cdn/overview/#transform-images) are available as modifiers for Nuxt Image.
+In addition to the [standard properties](https://image.nuxt.com/usage/nuxt-img), all of the [Netlify Image CDN transformation options](https://docs.netlify.com/image-cdn/overview/#transform-images) are available as modifiers for Nuxt Image.
 
 ```vue
 <NuxtImg

--- a/docs/content/3.providers/netlify.md
+++ b/docs/content/3.providers/netlify.md
@@ -8,21 +8,68 @@ links:
     size: xs
 ---
 
-::callout{color="amber" icon="i-ph-warning-duotone"}
-Netlify’s Large Media service is [deprecated](https://answers.netlify.com/t/large-media-feature-deprecated-but-not-removed/100804). If this feature is already enabled, Large Media will continue to work on these sites as usual. New Large Media configuration is not recommended.
-::
+When deploying your Nuxt applications to [Netlify's composable platform](https://docs.netlify.com/platform/overview/), the image module can use [Netlify Image CDN](https://docs.netlify.com/image-cdn/overview/) to optimize and transform images on demand without impacting build times. Netlify Image CDN also handles content negotiation to use the most efficient image format for the requesting client.
 
-Netlify offers dynamic image transformation for all JPEG, PNG, and GIF files you have set to be tracked with [Netlify Large Media](https://docs.netlify.com/large-media/overview/).
+To use Netlify Image CDN by default, add the following to your Nuxt configuration:
 
-::callout
-Before setting `provider: 'netlify'`, make sure you have followed the steps to enable [Netlify Large Media](https://docs.netlify.com/large-media/overview/).
-::
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  image: {
+    provider: 'netlify',
+  }
+})
+```
+
+## Remote images
+
+To transform a source image hosted on another domain, you must first configure allowed domains in your `netlify.toml` file.
+
+```toml [netlify.toml]
+[images]
+  remote_images = ["https://my-images.com/.*", "https://animals.more-images.com/[bcr]at/.*"]
+```
+
+The `remote_images` property accepts an array of regex. If your images are in specific subdomains or directories, you can use regex to allow just those subdomains or directories.
 
 ## Modifiers
 
-In addition to `height` and `width`, the Netlify provider supports the following modifiers:
+In addition to the [standard modifiers](https://image.nuxt.com/usage/nuxt-img#modifiers), all of the [Netlify Image CDN transformation options](https://docs.netlify.com/image-cdn/overview/#transform-images) are available as modifiers for Nuxt Image.
 
-### `fit`
+```vue
+<NuxtImg
+  provider="netlify"
+  src="owl.jpg"
+  :modifiers="{ 
+    h="400"
+    w="600"
+    fit="cover"
+    position="left"
+    fm="webp"
+    q="80"
+  }"
+/>
+```
+
+## Deprecated Netlify Large Media option
+
+::callout{color="amber" icon="i-ph-warning-duotone"}
+Netlify’s Large Media service is [deprecated](https://answers.netlify.com/t/large-media-feature-deprecated-but-not-removed/100804). If this feature is already enabled for your site on Netlify and you have already set `provider: 'netlify'` in your Nuxt configuration, then Large Media continues to work on your site as usual. However, new Large Media configuration is not recommended.
+::
+
+### Migrate to Netlify Image CDN
+
+To migrate from the deprecated Netlify Large Media option to the more robust Netlify Image CDN option, change `provider: 'netlify'` to `provider: 'netlifyImageCdn'`.
+
+
+### Use deprecated Netlify Large Media option
+
+If you're not ready to migrate to the more robust Netlify Image CDN option, Netlify continues to support dynamic image transformation for all JPEG, PNG, and GIF files you have set to be tracked with [Netlify Large Media](https://docs.netlify.com/large-media/overview/). 
+
+#### Large Media Modifiers
+
+In addition to `height` and `width`, the deprecated Netlify Large Media provider supports the following modifiers:
+
+##### `fit`
 
 * **Default**: `contain`
 * **Valid options**: `contain` (equivalent to `nf_resize=fit`) and `fill` (equivalent to `nf_resize=smartcrop`)


### PR DESCRIPTION
This PR adds docs for the Netlify Image CDN implementation proposed in https://github.com/nuxt/image/pull/1234

Very open to feedback as this is my first OSS contribution and I'm guessing a bit at what info is necessary to include in the Nuxt docs (as opposed to being made available through links to the Netlify docs) by looking at the docs for other providers. 